### PR TITLE
Refactor splitSchedule

### DIFF
--- a/internal/reloadSchedule/utils.go
+++ b/internal/reloadSchedule/utils.go
@@ -40,10 +40,10 @@ func splitSchedule(schedules map[int][]schedule.Lecture) (string, string) {
 	if len(schedules) == 2 {
 		return schedule.New(schedules[0]).Render(), schedule.New(schedules[1]).Render()
 	} else {
-		keys := GetKeys(schedules)
-		sort.Ints(keys)
+		timestamps := GetKeys(schedules)
+		sort.Ints(timestamps)
 		//if now time - time of 00:00 today < hours * minutes * seconds => time is today
-		if int(time.Now().Unix())-keys[0] < 24*60*60 {
+		if int(time.Now().Unix())-timestamps[0] < 24*60*60 {
 			return schedule.New(schedules[0]).Render(), schedule.New([]schedule.Lecture{}).Render()
 		} else {
 			return schedule.New([]schedule.Lecture{}).Render(), schedule.New(schedules[0]).Render()

--- a/internal/reloadSchedule/utils.go
+++ b/internal/reloadSchedule/utils.go
@@ -37,11 +37,11 @@ func GetKeys[T comparable, N any](v map[T]N) []T {
 }
 
 func splitSchedule(schedules map[int][]schedule.Lecture) (string, string) {
-	keys := GetKeys(schedules)
-	sort.Ints(keys)
 	if len(schedules) == 2 {
 		return schedule.New(schedules[0]).Render(), schedule.New(schedules[1]).Render()
 	} else {
+		keys := GetKeys(schedules)
+		sort.Ints(keys)
 		//if now time - time of 00:00 today < hours * minutes * seconds => time is today
 		if int(time.Now().Unix())-keys[0] < 24*60*60 {
 			return schedule.New(schedules[0]).Render(), schedule.New([]schedule.Lecture{}).Render()

--- a/internal/reloadSchedule/utils.go
+++ b/internal/reloadSchedule/utils.go
@@ -42,8 +42,8 @@ func splitSchedule(schedules map[int][]schedule.Lecture) (string, string) {
 	} else {
 		timestamps := GetKeys(schedules)
 		sort.Ints(timestamps)
-		//if now time - time of 00:00 today < hours * minutes * seconds => time is today
-		if int(time.Now().Unix())-timestamps[0] < 24*60*60 {
+		first := time.Unix(int64(timestamps[0]), 0)
+		if time.Since(first) < time.Hour*24 {
 			return schedule.New(schedules[0]).Render(), schedule.New([]schedule.Lecture{}).Render()
 		} else {
 			return schedule.New([]schedule.Lecture{}).Render(), schedule.New(schedules[0]).Render()


### PR DESCRIPTION
- Убрал переменные для проверки времени под else, ближе к использованию
- Улучшил наименования, но не до конца
- Упростил логику проверку, сегодняшнее ли число

Что можно исправить:

- Наименования

`timestamps` не лучшее название, но лучше `keys`. То же к `first` относится.

- Алгоритм

`sort` излишен, `min` решал бы ту же задачу быстрее.

- Логика

Функция берёт на себя слишком много - выделяет сегодняшнее/завтрашнее расписание И преобразует его.